### PR TITLE
Fix TR Localizable.strings

### DIFF
--- a/layout/Library/Application Support/uYouLocalization.bundle/tr.lproj/Localizable.strings
+++ b/layout/Library/Application Support/uYouLocalization.bundle/tr.lproj/Localizable.strings
@@ -115,7 +115,7 @@
 "Auto" = "Oto";
 
 "Videos Download Location" = "Videoların İndirme Konumu";
-"uYou Folder Only" = "Yalnızca "uYou" Klasörü";
+"uYou Folder Only" = "Yalnızca \"uYou\" Klasörü";
 "Camera Roll Only" = "Yalnızca Film Rulosu";
 "Both" = "İkisi de";
 


### PR DESCRIPTION
Here we go again, fixing another localization error.

It fixes the following error below.
```
2024-02-28 04:20:49.697 plutil[18983:48499] CFPropertyListCreateFromXMLData(): Old-style plist parser: missing semicolon in dictionary on line 118. Parsing will be abandoned. Break on _CFPropertyListMissingSemicolon to debug.
/Users/runner/work/TWEAK_NAME/TWEAK_NAME/main/.theos/_/Library/Application Support/uYouLocalization.bundle/tr.lproj/Localizable.strings: Property List error: Unexpected character / at line 1 / JSON error: JSON text did not start with array or object and option to allow fragments not set. around line 1, column 0.
```